### PR TITLE
Fix FeatureNormalizer to handle Integer Matrix

### DIFF
--- a/src/feature_scaling.jl
+++ b/src/feature_scaling.jl
@@ -76,7 +76,14 @@ function StatsBase.predict!{T<:Real}(cs::FeatureNormalizer, X::AbstractMatrix{T}
     X
 end
 
-function StatsBase.predict{T<:Real}(cs::FeatureNormalizer, X::AbstractMatrix{T})
+function StatsBase.predict{T<:AbstractFloat}(cs::FeatureNormalizer, X::AbstractMatrix{T})
     Xnew = copy(X)
     StatsBase.predict!(cs, Xnew)
 end
+
+function StatsBase.predict{T<:Real}(cs::FeatureNormalizer, X::AbstractMatrix{T})
+    X = convert(AbstractMatrix{AbstractFloat}, X)
+    StatsBase.predict!(cs, X)
+end
+
+


### PR DESCRIPTION
This fix allows Integer Matrix to be passed to `predict()` for `FeatureNormalizer`